### PR TITLE
npm install -g elm-new

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ For **Linux**, **Mac**, and **Windows**, open a terminal and run:
 
     curl https://raw.githubusercontent.com/simonewebdesign/elm-new/master/install.sh | sh
 
+#### From npm
+
+    npm install -g elm-new
+
 For other installation options, see [here](https://github.com/simonewebdesign/elm-new/blob/master/INSTALL.md).
 
 ---

--- a/bin/elm-new
+++ b/bin/elm-new
@@ -13,7 +13,7 @@ for arg in "$@"; do
       ;;
 
     -V|--version)
-      echo "1.1.1a"
+      echo "1.1.2"
       exit
       ;;
 

--- a/bin/elm-new
+++ b/bin/elm-new
@@ -13,7 +13,7 @@ for arg in "$@"; do
       ;;
 
     -V|--version)
-      echo "1.1.2"
+      echo "1.1.3"
       exit
       ;;
 

--- a/elm-new.bat
+++ b/elm-new.bat
@@ -18,11 +18,11 @@ for %%a in (%*) do (
         exit /b
 
     ) else if %%a == --version (
-        echo 1.1.1a
+        echo 1.1.2
         exit /b
 
     ) else if %%a == -V (
-        echo 1.1.1a
+        echo 1.1.2
         exit /b
 
     ) else if %%a == --beginner (

--- a/elm-new.bat
+++ b/elm-new.bat
@@ -18,11 +18,11 @@ for %%a in (%*) do (
         exit /b
 
     ) else if %%a == --version (
-        echo 1.1.2
+        echo 1.1.3
         exit /b
 
     ) else if %%a == -V (
-        echo 1.1.2
+        echo 1.1.3
         exit /b
 
     ) else if %%a == --beginner (

--- a/index.js
+++ b/index.js
@@ -1,9 +1,12 @@
 #!/usr/bin/env node
 
-const spawn = require('child_process').spawnSync
-const cli = require('os').platform() === 'win32' ? 'elm-new.bat' : 'bin/elm-new'
-const cmd = spawn(cli, process.argv.slice(2))
+spawn = require('child_process').spawnSync
+cli = require('os').platform() === 'win32' ? __dirname + '/elm-new.bat' : __dirname + '/bin/elm-new'
+cmd = spawn(cli, process.argv.slice(2))
 
-if (cmd.stderr) console.error(cmd.stderr.toString())
-if (cmd.stdout) console.log(cmd.stdout.toString())
-if (cmd.stderr) process.exit(1)
+stderr = cmd.stderr.toString()
+stdout = cmd.stdout.toString()
+
+if (stderr !== '') console.error(stderr)
+if (stdout !== '') console.log(stdout)
+if (stderr !== '') process.exit(1)

--- a/index.js
+++ b/index.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+const spawn = require('child_process').spawnSync
+const cli = require('os').platform() === 'win32' ? 'elm-new.bat' : 'bin/elm-new'
+const cmd = spawn(cli, process.argv.slice(2))
+
+if (cmd.stderr) console.error(cmd.stderr.toString())
+if (cmd.stdout) console.log(cmd.stdout.toString())
+if (cmd.stderr) process.exit(1)

--- a/index.js
+++ b/index.js
@@ -4,6 +4,9 @@ spawn = require('child_process').spawnSync
 cli = require('os').platform() === 'win32' ? __dirname + '/elm-new.bat' : __dirname + '/bin/elm-new'
 cmd = spawn(cli, process.argv.slice(2))
 
+// npm will rename .gitignore to .npmignore at publish time. See: https://github.com/npm/npm/issues/14216
+spawn('mv', [__dirname + '/share/elm-new/.npmignore', __dirname + '/share/elm-new/.gitignore'])
+
 stderr = cmd.stderr.toString()
 stdout = cmd.stdout.toString()
 

--- a/install.bat
+++ b/install.bat
@@ -4,17 +4,17 @@ echo Initializing...
 mkdir C:\Tools\elm-new
 
 echo Downloading...
-powershell -Command "(New-Object Net.WebClient).DownloadFile('https://codeload.github.com/simonewebdesign/elm-new/zip/v1.1.2', 'C:\Tools\elm-new\elm-new.zip')"
+powershell -Command "(New-Object Net.WebClient).DownloadFile('https://codeload.github.com/simonewebdesign/elm-new/zip/v1.1.3', 'C:\Tools\elm-new\elm-new.zip')"
 
 echo Extracting...
 call :unzip "C:\Tools\elm-new" "C:\Tools\elm-new\elm-new.zip"
 
 echo Installing...
-robocopy C:\Tools\elm-new\elm-new-1.1.2 C:\Tools\elm-new /e >nul 2>&1
+robocopy C:\Tools\elm-new\elm-new-1.1.3 C:\Tools\elm-new /e >nul 2>&1
 
 echo Cleaning...
 del C:\Tools\elm-new\elm-new.zip
-rmdir /s /q C:\Tools\elm-new\elm-new-1.1.2
+rmdir /s /q C:\Tools\elm-new\elm-new-1.1.3
 
 echo Done!
 exit /b

--- a/install.bat
+++ b/install.bat
@@ -4,17 +4,17 @@ echo Initializing...
 mkdir C:\Tools\elm-new
 
 echo Downloading...
-powershell -Command "(New-Object Net.WebClient).DownloadFile('https://codeload.github.com/simonewebdesign/elm-new/zip/v1.1.1a', 'C:\Tools\elm-new\elm-new.zip')"
+powershell -Command "(New-Object Net.WebClient).DownloadFile('https://codeload.github.com/simonewebdesign/elm-new/zip/v1.1.2', 'C:\Tools\elm-new\elm-new.zip')"
 
 echo Extracting...
 call :unzip "C:\Tools\elm-new" "C:\Tools\elm-new\elm-new.zip"
 
 echo Installing...
-robocopy C:\Tools\elm-new\elm-new-1.1.1a C:\Tools\elm-new /e >nul 2>&1
+robocopy C:\Tools\elm-new\elm-new-1.1.2 C:\Tools\elm-new /e >nul 2>&1
 
 echo Cleaning...
 del C:\Tools\elm-new\elm-new.zip
-rmdir /s /q C:\Tools\elm-new\elm-new-1.1.1a
+rmdir /s /q C:\Tools\elm-new\elm-new-1.1.2
 
 echo Done!
 exit /b

--- a/install.sh
+++ b/install.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # Download and unpack
-curl https://codeload.github.com/simonewebdesign/elm-new/tar.gz/v1.1.2 > elm-new.tar.gz
+curl https://codeload.github.com/simonewebdesign/elm-new/tar.gz/v1.1.3 > elm-new.tar.gz
 tar -zxf elm-new.tar.gz
 
 # Install
-cd elm-new-1.1.2
+cd elm-new-1.1.3
 sudo make install && echo 'elm-new installed successfully!'
 
 # Cleanup
 cd ..
-rm -R elm-new-1.1.2 elm-new.tar.gz
+rm -R elm-new-1.1.3 elm-new.tar.gz

--- a/install.sh
+++ b/install.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # Download and unpack
-curl https://codeload.github.com/simonewebdesign/elm-new/tar.gz/v1.1.1a > elm-new.tar.gz
+curl https://codeload.github.com/simonewebdesign/elm-new/tar.gz/v1.1.2 > elm-new.tar.gz
 tar -zxf elm-new.tar.gz
 
 # Install
-cd elm-new-1.1.1a
+cd elm-new-1.1.2
 sudo make install && echo 'elm-new installed successfully!'
 
 # Cleanup
 cd ..
-rm -R elm-new-1.1.1a elm-new.tar.gz
+rm -R elm-new-1.1.2 elm-new.tar.gz

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "elm-new",
+  "version": "1.1.2",
+  "description": "Generates a project scaffolding for rapid prototyping of Elm apps.",
+  "main": "index.js",
+  "bin": {
+    "elm-new": "./index.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/simonewebdesign/elm-new.git"
+  },
+  "keywords": [
+    "elm",
+    "new",
+    "init",
+    "cli"
+  ],
+  "author": "Simone Vittori <hello+npm@simonewebdesign.it>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/simonewebdesign/elm-new/issues"
+  },
+  "homepage": "https://github.com/simonewebdesign/elm-new#readme"
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-new",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Generates a project scaffolding for rapid prototyping of Elm apps.",
   "main": "index.js",
   "bin": {

--- a/test.sh
+++ b/test.sh
@@ -41,10 +41,10 @@ test "prints help (--help)"
 if [[ $($cli --help) == "usage:"* ]]; then ok; else fail; fi
 
 test "prints version (-V)"
-if [ "$($cli -V)" == "1.1.2" ]; then ok; else fail; fi
+if [ "$($cli -V)" == "1.1.3" ]; then ok; else fail; fi
 
 test "prints version (--version)"
-if [ "$($cli --version)" == "1.1.2" ]; then ok; else fail; fi
+if [ "$($cli --version)" == "1.1.3" ]; then ok; else fail; fi
 
 echo When invalid arg provided,
 test "    prints to stderr"

--- a/test.sh
+++ b/test.sh
@@ -41,10 +41,10 @@ test "prints help (--help)"
 if [[ $($cli --help) == "usage:"* ]]; then ok; else fail; fi
 
 test "prints version (-V)"
-if [ "$($cli -V)" == "1.1.1a" ]; then ok; else fail; fi
+if [ "$($cli -V)" == "1.1.2" ]; then ok; else fail; fi
 
 test "prints version (--version)"
-if [ "$($cli --version)" == "1.1.1a" ]; then ok; else fail; fi
+if [ "$($cli --version)" == "1.1.2" ]; then ok; else fail; fi
 
 echo When invalid arg provided,
 test "    prints to stderr"


### PR DESCRIPTION
elm-new has been wrapped in an npm package for alternative installation.

Now it's possible to do:

```
npm install -g elm-new
```
