### PR TITLE
Unhardcode bash

### DIFF
--- a/bin/elm-new
+++ b/bin/elm-new
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 choice=default
 path=.

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Download and unpack
 curl https://codeload.github.com/simonewebdesign/elm-new/tar.gz/v1.3.0 > elm-new.tar.gz

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cli=$1
 


### PR DESCRIPTION
Not all unix like systems keep bash at `/bin/bash`, a lot of bsds and some linux distros don't while `/usr/bin/env` is present.